### PR TITLE
Fix: add variaveis de ambiente no dockercompose

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,10 @@
+#JWT
 JWT_SECRET="ISHAU#*!#(!)#!_--1-SHhhsss_102901_*$(#&#!)@!)@12_"
-DATABASE_URL="postgresql://user:pass@usersdb:5432//db?schema=public"
+
+#POSTGRES
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+POSTGRES_DB=postgres
+
+# Segue o padrão "postgresql://<USER>:<PASSWORD>@<CONTAINER_DB>:<PORT>/<DATABASE>?schema=public"
+DATABASE_URL="postgresql://postgres:password@usersdb:5432/postgres?schema=public"

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,11 @@ lerna-debug.log*
 !.vscode/extensions.json
 
 # dotenv environment variable files
-
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
 
 # temp directory
 .temp

--- a/README.md
+++ b/README.md
@@ -3,32 +3,40 @@
 </p>
 The Docunder project is a platform for technical documentation of hardware, software, and methodologies, aiming to be collaborative and lightweight. It can be used by a server for institution-controlled access, allowing for the creation, editing, sharing and efficient organization of technical documents.
 
-## Usage
+## Usage 🏗
 ### For this project you will need [Node](https://nodejs.org/en) and [Docker](https://docs.docker.com/get-docker/) installed in your computer.
-
+<!--
 First of all you need to install all dependecies:
   ```bash
 $ npm install
 ```
+-->
 
-## Docker
-Before running the project, you will need to set the Postgres credentions you want to use in the `docker-compose.yaml` file. <br>
+## Environment 🌲
+Before running the project, you will need to set the Postgres credentions you want to use in the `.env` file. <br>
 Just change this lines with the user/password you prefer.
 ```
-environment:
-   POSTGRES_PASSWORD: yourUser
-   POSTGRES_USER: yourPassword
+POSTGRES_USER="postgres"
+POSTGRES_PASSWORD="password"
+POSTGRES_DB="postgres"
+```
+<br>
+Also don't forget to the SAME credentials in the URL, as the example
+
+```
+# Follow this pattern: "postgresql://<USER>:<PASSWORD>@<CONTAINER_DB>:<PORT>/<DATABASE>?schema=public"
+DATABASE_URL="postgresql://postgres:password@usersdb:5432/postgres?schema=public"
 ```
 
-> [!NOTE]
-> This is being fix on issue https://github.com/Organizacao-Docunder/base-system/issues/1 .
 
-## Running the app
+## Running the app ⚙
 Now that everythings has been set up, you can run all the containers by:
 ```bash
 $ docker-compose up -d
 ```
 You can acess the app at http://localhost:3000/ from your host system.
+<br>
+You can also use `docker-compose up --build` to force Docker to rebuild the container, if you think some of your code was not added up.
 
 
 #### If you want to stop the containers use:
@@ -36,7 +44,7 @@ You can acess the app at http://localhost:3000/ from your host system.
 $ docker-compose down
 ```
 
-## Stay in touch
+## Stay in touch 🙋‍♂️
 
 - [Linkedin](https://www.linkedin.com/company/docunder/)
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,8 +19,11 @@ services:
                   networks:
                     - "app-network"
                   environment:
-                    POSTGRES_PASSWORD: 
-                    POSTGRES_USER: 
+                    POSTGRES_USER: ${POSTGRES_USER}
+                    POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+                    POSTGRES_DB: ${POSTGRES_DB}
+                  env_file:
+                    - .env
                   ports:
                     - "5432:5432"
                     


### PR DESCRIPTION
As variaveis de configuração do postgres eram passadas por em plain text dentro do arquivo do docker-compose.yaml, não sendo nada interessante no quesito de segurança.

Atualmente são passadas através do arquivo `.env`

```
//docker-compose.yaml
                  environment:
                    POSTGRES_USER: ${POSTGRES_USER}
                    POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
                    POSTGRES_DB: ${POSTGRES_DB}
                  env_file:
                    - .env
```