### PR TITLE
chore: novo issue template para bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Template para a descrição de um bug report
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+## Título
+Título simples e objetivo do problema. Imagine como um super resumo do problema.
+Também deverá ser o título da issue, precedido pela tag [BUG]
+Ex: [BUG] Campo 'nome' aceitando valores numéricos na página de cadastro.
+
+## Prioridade
+Prioridade da resolução do bug. Escolha entre uma
+‼ **HOTFIX**
+🚨 Alto
+⚡Medio
+🧊 Baixo
+
+## Task
+Identificador da funcionalidade ao qual esse bug esta correlacionado.
+
+## Descrição
+Uma descrição clara e concisa do problema. Seja detalhista e evite ambiguidades.
+
+## Passos para reproduzir
+Passo a passo para reproduzir o ocorrido:
+1. Acesse a página ...
+2. Clique em ...
+3. Preencha o botão ...
+4. O erro 'xx' aparece
+
+## Resultado esperado
+Uma descrição clara e concisa do que deveria acontecer.
+
+## Ambiente
+Browser: Chrome Beowser verion 21.7.9
+
+## Evidência
+Foto ou vídeo do problema, caso aplicável.


### PR DESCRIPTION
Adicionado um novo template para geração de bugs reports.

Para utilizar ele é só escrever /templates na descrição da issue.