### PR TITLE
fix: prisma schema path with dockercompose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN adduser -S backend -u 1001
 COPY package*.json ./
 COPY tsconfig.json ./
 COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/src/prisma ./dist/prisma
 COPY --from=builder /app/dist ./dist
 
 COPY --chown=backend:production docker-entrypoint.sh ./

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
         context: "./"
     container_name: docunder-backend
     restart: always
-    command: ./docker-entrypoint.sh
+    command: /app/docker-entrypoint.sh
     networks:
       - docunder-network
       - db-network

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
         context: "./"
     container_name: docunder-backend
     restart: always
-    command: /app/docker-entrypoint.sh
+    command: sh /app/docker-entrypoint.sh
     networks:
       - docunder-network
       - db-network

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ echo "Waiting for Postgres to start..."
 wget -qO- https://raw.githubusercontent.com/eficode/wait-for/v2.2.4/wait-for | sh -s -- postgres:5432
 
 echo "Migrating the databse..."
-npx prisma migrate deploy
+npx prisma migrate deploy --schema=/app/dist/prisma/schema.prisma
 
 echo "Starting the server..."
 node dist/main.js


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (documentation, packages, or tests updates, nothing that affect the final user directly)
- [ ] Release (new version of the application - only for production)

## Description

Adjusting `prisma schema` path when running trough `Docker Compose` and making sure the `docker-entrypoint.sh` run correctly on multiples SO

